### PR TITLE
Improve portability of /etc/r10k.yaml ownership

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,8 +49,8 @@ class r10k::config (
 
   file { '/etc/r10k.yaml':
     ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
+    owner   => 0,
+    group   => 0,
     content => template('r10k/r10k.yaml.erb'),
   }
 


### PR DESCRIPTION
Setting the 'owner' and 'group' values to 0 ensures they will get the OS perspective of the root/wheel group.
