### PR TITLE
added options to set path, owner, group of r10k.yaml config file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,12 +45,16 @@ class r10k::config (
   $cachedir  = '/var/cache/r10k',
   $sources   = {},
   $purgedirs = [],
+  $config_path = '/etc',
+  $config_owner = 'root',
+  $config_group = 'root',
 ){
 
-  file { '/etc/r10k.yaml':
+  file { 'r10k.yaml':
+    path    => "$config_path/$title",
     ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $config_owner,
+    group   => $config_group,
     content => template('r10k/r10k.yaml.erb'),
   }
 


### PR DESCRIPTION
Here is a proposed change to enable different path, owner and group for the r10k.yaml file, while retaining the current defaults. This code is currently untested...
