### PR TITLE
Add ability to install r10k from rpm packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,5 +14,9 @@
 # Michael Gruener <michael.gruener@chaosmoon.net>
 #
 class r10k {
-  include r10k::install::gem
+  if $::osfamily == 'RedHat' {
+    include r10k::install::rpm
+  } else {
+    include r10k::install::gem
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,25 +4,15 @@
 #
 # === Parameters
 #
-# [*ensure*]
-#   Version of r10k to install. Accepts any ensure state that is valid for the
-#   Package type. Default: present
-#
 # === Examples
 #
-#  class { r10k: ensure => '1.0.0' }
+#  class { r10k: }
 #
 # === Authors
 #
 # Charlie Sharpsteen <source@sharpsteen.net>
+# Michael Gruener <michael.gruener@chaosmoon.net>
 #
-class r10k (
-  $ensure = 'present',
-){
-
-  package { 'r10k':
-    ensure   => $ensure,
-    provider => 'gem',
-  }
-
+class r10k {
+  include r10k::install::gem
 }

--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -1,0 +1,29 @@
+# == Class: r10k::install::gem
+#
+# Install r10k (gem).
+#
+# === Parameters
+#
+# [*ensure*]
+#   Version of r10k to install. Accepts any ensure state that is valid for the
+#   Package type. Default: present
+#
+# === Examples
+#
+#  class { r10k::install::gem: ensure => '1.0.0' }
+#
+# === Authors
+#
+# Charlie Sharpsteen <source@sharpsteen.net>
+# Michael Gruener <michael.gruener@chaosmoon.net>
+#
+class r10k::install::gem (
+  $ensure = 'present',
+){
+
+  package { 'r10k':
+    ensure   => $ensure,
+    provider => 'gem',
+  }
+
+}

--- a/manifests/install/rpm.pp
+++ b/manifests/install/rpm.pp
@@ -43,6 +43,7 @@ class r10k::install::rpm (
 
     package { 'rubygem-r10k':
       ensure   => $ensure,
+      require  => Yumrepo['r10k'],
     }
   } else {
     fail('The class r10k::install::rpm is only intended for RedHat style systems (Fedora / Centos / RHEL).')

--- a/manifests/install/rpm.pp
+++ b/manifests/install/rpm.pp
@@ -1,0 +1,50 @@
+# == Class: r10k::install::rpm
+#
+# Install r10k (rpm).
+#
+# === Parameters
+#
+# [*ensure*]
+#   Version of r10k to install. Accepts any ensure state that is valid for the
+#   Package type. Default: present
+# [*ensure_repo*]
+#   Use a custom repository to install the r10k rpms from
+# [*repo_baseurl*]
+#   The baseurl for the repository
+#
+# === Examples
+#
+#  class { r10k::install::rpm:
+#    ensure       => '1.0.0',
+#    ensure_repo  => 'absent',
+#    repo_baseurl => 'http://copr-be.cloud.fedoraproject.org/results/jonkelley/r10k/epel-6-$basearch/'
+#  }
+#
+# === Authors
+#
+# Charlie Sharpsteen <source@sharpsteen.net>
+# Michael Gruener <michael.gruener@chaosmoon.net>
+#
+
+class r10k::install::rpm (
+  $ensure       = 'present',
+  $ensure_repo  = 'present',
+  $repo_baseurl = 'http://copr-be.cloud.fedoraproject.org/results/jonkelley/r10k/epel-6-$basearch/'
+) {
+  if $::osfamily == 'RedHat' {
+    yumrepo { 'r10k':
+      ensure              => $ensure_repo,
+      descr               => 'r10k repository',
+      baseurl             => $repo_baseurl,
+      skip_if_unavailable => 'True',
+      gpgcheck            => '0',
+
+    }
+
+    package { 'rubygem-r10k':
+      ensure   => $ensure,
+    }
+  } else {
+    fail('The class r10k::install::rpm is only intended for RedHat style systems (Fedora / Centos / RHEL).')
+  }
+}


### PR DESCRIPTION
By moving the code responsible for the r10k installation to its own class, it is possible to add new installation methods. In this case I have added the option to install r10k from a rpm repository on RedHat based systems.
