### PR TITLE
Remove purgedirs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,6 @@ The `r10k::config` class manages the contents of `/etc/r10k.yaml` and accepts th
     Hash containing data sources to be used by r10k to create dynamic Puppet environments.
     Default: `{}`
 
-  * `purgedirs`:
-   An Array of directory paths to purge of any subdirectories that do not correspond to a dynamic environment managed by r10k.
-   Default: `[]`
-
 Detailed information on these parameters can be found in the [r10k documentation][r10k-docs].
 
 The `r10k::config` class is designed to be used in conjunction with Hiera data:
@@ -89,10 +85,6 @@ r10k::config::sources:
   someothername:
     remote: 'ssh://git@github.com/someuser/someotherrepo.git'
     basedir: '/some/other/basedir'
-
-r10k::config::purgedirs:
-  - '%{::settings::confdir}/environments'
-  - '/some/other/basedir/
 ```
 
 ```puppet
@@ -115,10 +107,6 @@ class { 'r10k::config':
       'basedir' => '/some/other/basedir'
     },
   },
-  purgedirs => [
-    "${::settings::confdir}/environments",
-    '/some/other/basedir',
-  ],
 }
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,9 +10,6 @@
 # * [*sources*]
 #   Hash containing data sources to be used by r10k to create dynamic Puppet
 #   environments. Default: {}
-# * [*purgedirs*]
-#   An Array of directory paths to purge of any subdirectories that do not
-#   correspond to a dynamic environment managed by r10k. Default: []
 # * [*path*]
 #   The path at which the r10k config is written. Default: /etc/r10k.yaml
 # * [*owner*]
@@ -35,10 +32,6 @@
 #        'basedir' => '/some/other/basedir'
 #      },
 #    },
-#    purgedirs => [
-#      "${::settings::confdir}/environments",
-#      '/some/other/basedir',
-#    ],
 #  }
 #
 # == Documentation
@@ -52,7 +45,6 @@
 class r10k::config (
   $cachedir  = '/var/cache/r10k',
   $sources   = {},
-  $purgedirs = [],
   $path = '/etc/r10k.yaml',
   $owner = 'root',
   $group = 'root',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -13,10 +13,6 @@ describe 'r10k::config', :type => :class do
           'basedir' => '/some/other/basedir'
         },
       },
-      'purgedirs' => [
-        "${::settings::confdir}/environments",
-        '/some/other/basedir',
-      ],
     }
   }
 
@@ -35,10 +31,6 @@ describe 'r10k::config', :type => :class do
     # YAML dumps of Ruby objects.
     it 'creates a hash of sources' do
       expect(content[:sources]).to be_a(Hash)
-    end
-
-    it 'creates an array of purgedirs' do
-      expect(content[:purgedirs]).to be_a(Array)
     end
   end
 end

--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -6,9 +6,3 @@
 <%# The splitting/joining monkeybuisness trims the YAML document header: `---` -%>
 <%= @sources.to_yaml.split("\n")[1..-1].join("\n") %>
 <% end -%>
-
-<%# The Array boxing/flattening ensures we don't get bitten by bug #15813 -%>
-<% unless [@purgedirs].flatten.empty? -%>
-:purgedirs:
-<%= [@purgedirs].flatten.to_yaml.split("\n")[1..-1].join("\n") %>
-<% end -%>


### PR DESCRIPTION
r10k never seemed to actually use the purgedirs option in
the configuration. So it was removed from the documentation some
time ago. See adrienthebo/r10k@ea4495aba839d0280bd0ce6c47b63650393fbc68.
